### PR TITLE
Pick distro name from release information

### DIFF
--- a/scripts/setup_debian.sh
+++ b/scripts/setup_debian.sh
@@ -28,9 +28,9 @@ apt update
 apt install -y apt-transport-https ca-certificates ne curl gnupg2 software-properties-common
 
 # Add docker repositry
-curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+curl -fsSL https://download.docker.com/linux/$(lsb_release -is | tr 'A-Z' 'a-z')/gpg | apt-key add -
 add-apt-repository \
-          "deb [arch=amd64] https://download.docker.com/linux/debian \
+          "deb [arch=amd64] https://download.docker.com/linux/$(lsb_release -is | tr 'A-Z' 'a-z') \
            $(lsb_release -cs) \
            stable"
            


### PR DESCRIPTION
Since this file is used for both ubuntu and debian, I noticed that the docker repository used only caters to debian